### PR TITLE
Remove duplicate entries for nested directories 

### DIFF
--- a/src/archive/har.d
+++ b/src/archive/har.d
@@ -400,7 +400,7 @@ struct HarCompressor
     {
         assert(isDir(path));
 
-        auto entries = dirEntries(path, SpanMode.breadth);
+        auto entries = dirEntries(path, SpanMode.shallow);
 
         // Generate a named entry for empty directories
         if (entries.empty)

--- a/test/cli/compression/directories/expected.har
+++ b/test/cli/compression/directories/expected.har
@@ -17,12 +17,3 @@ void print(const char* msg)
 {
     puts(msg);
 }
---- nested/util/helper.d
-module nested.util.helper;
-
-import core.stdc.stdio;
-
-void print(const char* msg)
-{
-    puts(msg);
-}


### PR DESCRIPTION
Don't descend into subdirectories via `dirEntries` in addition to the
existing recursion.