### PR TITLE
Normalize path seperator on Windows   

### DIFF
--- a/src/archive/har.d
+++ b/src/archive/har.d
@@ -21,11 +21,11 @@ void foofunc()
 module archive.har;
 
 import std.typecons : Flag, Yes, No;
-import std.array : Appender;
+import std.array : Appender, join;
 import std.format : format;
 import std.string : startsWith, indexOf, stripRight;
 import std.utf : decode, replacementDchar;
-import std.path : dirName, buildPath;
+import std.path : dirName, buildPath, pathSplitter;
 import std.file : dirEntries, DirEntry, exists, isDir, mkdirRecurse, SpanMode;
 import std.stdio : File;
 
@@ -470,7 +470,13 @@ private:
      +/
     void writeHeader(T...)(scope T path, scope lazy Attributes attributes)
     {
-        archive.write(delimiter, ' ', formatQuotedIfSpaces(path));
+        // Normalize Windows paths to use / instead of \
+        version (Windows)
+            auto quoted = formatQuotedIfSpaces(path[0].pathSplitter().join('/'), path[1..$]);
+        else
+            auto quoted = formatQuotedIfSpaces(path);
+
+        archive.write(delimiter, ' ', quoted);
         writeProperties(attributes);
     }
 

--- a/test/cli/test_command_line_tool.d
+++ b/test/cli/test_command_line_tool.d
@@ -50,7 +50,6 @@ int tryMain(string[] args)
     if (const status = runExtractionTests(testDir, outDir, harExe))
         return status;
 
-    version (Windows) {} else // TODO: Fix directory seperators
     if (const status = runCompressionTests(testDir, outDir, harExe))
         return status;
 


### PR DESCRIPTION
Consistently use / instead of \