### PR TITLE
CLI: Add option to generate a summary of all extracted files 

### DIFF
--- a/harmain.d
+++ b/harmain.d
@@ -46,6 +46,7 @@ int tryMain(string[] args)
     }
 
     string outputDirOption = null;
+    string summaryPath = null;
     bool quietMode = false;
     bool verbose = false;
     bool dryRun = false;
@@ -63,6 +64,8 @@ int tryMain(string[] args)
             }
             else if (arg.startsWith("--dir="))
                 outputDirOption = arg[6 .. $];
+            else if (arg.startsWith("--summary="))
+                summaryPath = arg["--summary=".length .. $];
             else if (arg == "--quiet")
                 quietMode = true;
             else if (arg == "--verbose")
@@ -133,6 +136,23 @@ int tryMain(string[] args)
         handleNewOutputDir(outputDirOption);
     }
 
+    File summaryFile;
+    if (summaryPath)
+    {
+        import std.path;
+        const dir = dirName(summaryPath);
+        if (!exists(dir))
+        {
+            stderr.writeln("Directory for summary file doesn't exist: ", dir);
+            return 1;
+        }
+
+        if (verbose)
+            writeln("Creating summary file: ", summaryPath);
+
+        summaryFile = File(summaryPath, "w");
+    }
+
     foreach(harFilename; args)
     {
         auto extractor = HarExtractor();
@@ -156,6 +176,8 @@ int tryMain(string[] args)
             {
                 writeln(fullFileName);
             }
+            if (summaryPath)
+                summaryFile.writeln(fileProps.filename, '|', fileProps.offset);
         });
     }
     return 0;

--- a/src/archive/har.d
+++ b/src/archive/har.d
@@ -102,6 +102,8 @@ struct HarExtractor
         for (;;)
         {
             auto fileInfo = parseFileLine(line[delimiter.length .. $], delimiter[0]);
+            fileInfo.offset = lineNumber + 1; // First line following --- app.d
+
             auto fullFileName = buildPath(outputDir, fileInfo.filename);
             fileInfoCallback(fullFileName, fileInfo);
 
@@ -290,6 +292,17 @@ private bool isEndOfFileChar(C)(const(C) c)
 struct FileProperties
 {
     const(char)[] filename;
+
+    /++
+     + Absolute line number in the HAR file that contains the first line of the
+     + current file, e.g. `2` for `app.d` in the following example:
+     +
+     + ```
+     + --- app.d
+     + void main() {}
+     + ```
+     +/
+    size_t offset;
 }
 
 auto formatDir(const(char)[] dir)

--- a/test/cli/test_command_line_tool.d
+++ b/test/cli/test_command_line_tool.d
@@ -66,10 +66,18 @@ int runExtractionTests(const string testBaseDir, const string outBaseDir, const 
     {
         auto file = entry.name;
         auto name = file.baseName.setExtension(".expected");
-        run(format("%s %s --dir=%s", harExe, file, outTestDir.buildPath(name)));
+
         auto expected = file.setExtension(".expected");
         auto actual = outTestDir.buildPath(name);
-        run(format("diff --brief -r %s %s", expected, actual));
+
+        auto cmd = format("%s %s --dir=%s", harExe, file, actual);
+
+        const summary = buildPath(expected, "summary.txt");
+        if (exists(summary))
+            cmd ~= " --summary=" ~ actual ~ "/summary.txt";
+
+        run(cmd);
+        runProcess([ "git", "diff", "--no-index", "--ignore-space-at-eol", "--exit-code", expected, actual ]);
     }
     return 0;
 }

--- a/test/hartests.d
+++ b/test/hartests.d
@@ -80,17 +80,30 @@ void testError(string text, size_t lineOfError, string error, size_t testLine = 
         assert(e.line == lineOfError);
     }
 }
-void test(string text, string[] expectedFilenames, size_t testLine = __LINE__)
+
+void testImpl(T)(string text, T[] expected, size_t testLine = __LINE__)
 {
     auto extractor = HarExtractor();
     extractor.filenameForErrors = format("%s_line_%s", __FILE__, testLine);
     extractor.dryRun = true;
-    auto extractedFiles = appender!(string[]);
-    extractor.extract(text.lineSplitter, delegate(string fileFullName, FileProperties props) {
-        extractedFiles.put(fileFullName);
+    auto extractedFiles = appender!(T[]);
+    extractor.extract(text.lineSplitter, delegate(string fileFullName, FileProperties props)
+    {
+        static if (is(T == string))
+        {
+            extractedFiles.put(fileFullName);
+        }
+        else
+        {
+            extractedFiles.put(props);
+        }
+
     });
-    assert(expectedFilenames == extractedFiles.data);
+    assert(expected == extractedFiles.data);
 }
+
+alias test = testImpl!string;
+alias testSummary = testImpl!FileProperties;
 
 version(D_Coverage)
 shared static this()

--- a/test/hartests.d
+++ b/test/hartests.d
@@ -60,6 +60,23 @@ void main()
         testError(s[0] ~ "\xe2\x82\x28" ~ s[1], 1, "invalid utf8 sequence");
         test     (s[0] ~ "\xf0\x90\x8c\xbc" ~ s[1], ["\xf0\x90\x8c\xbc"]);
     }
+
+    // Test summaries
+`--- base.d
+This is some text.
+
+And some more!
+
+--- lib.d
+Here's some more.
+
+--- view/foo.txt
+Hello, World!
+`.testSummary([
+    FileProperties("base.d", 2),
+    FileProperties("lib.d", 7),
+    FileProperties("view/foo.txt", 10),
+]);
 }
 
 void testError(string text, size_t lineOfError, string error, size_t testLine = __LINE__)

--- a/test/summaries.expected/base.d
+++ b/test/summaries.expected/base.d
@@ -1,0 +1,4 @@
+This is some text.
+
+And some more!
+

--- a/test/summaries.expected/lib.d
+++ b/test/summaries.expected/lib.d
@@ -1,0 +1,2 @@
+Here's some more.
+

--- a/test/summaries.expected/summary.txt
+++ b/test/summaries.expected/summary.txt
@@ -1,0 +1,3 @@
+base.d|2
+lib.d|7
+view/foo.txt|10

--- a/test/summaries.expected/view/foo.txt
+++ b/test/summaries.expected/view/foo.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/summaries.har
+++ b/test/summaries.har
@@ -1,0 +1,10 @@
+--- base.d
+This is some text.
+
+And some more!
+
+--- lib.d
+Here's some more.
+
+--- view/foo.txt
+Hello, World!


### PR DESCRIPTION
`har --summary=<file>` will now generate a list of all files in the
archive. Each line denotes a new file and is read as
`<file specification>|<line in the archive>`.

This supplements the existing output that writes the absolute path of
each extracted file.

TODO:
- extend this for compression?